### PR TITLE
Fix updating problem

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -99,13 +99,15 @@ void format_uptime(UptimeApplet *applet, char *s, char *t) {
 /*
  * Update the applet
  */
-void applet_check_uptime(UptimeApplet *applet) {
+int applet_check_uptime(UptimeApplet *applet) {
 	get_uptime(applet);
 	char uptime[128], tooltip[1024]; 
 
 	format_uptime(applet, &uptime[0], &tooltip[0]);
 	gtk_label_set_markup(GTK_LABEL(applet->label_bottom), &uptime[0]);
 	gtk_widget_set_tooltip_text (GTK_WIDGET (applet->applet), &tooltip[0]);
+	
+	return TRUE;
 }
 
 /* The "main" function


### PR DESCRIPTION
This appears to fix the problem of the applet not refreshing. It only refreshed once because applet_check_uptime was not returning a value. The documentation I found for the function g_timeout_add said the function specified will only be run at regular intervals as long as it don't return FALSE.

https://developer.gnome.org/glib/stable/glib-The-Main-Event-Loop.html#g-timeout-add