### PR TITLE
Fix error when compling against new version of gtk

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -37,10 +37,10 @@ void about_cb (GtkAction *action, UptimeApplet *applet) {
 
 	gtk_about_dialog_set_copyright (GTK_ABOUT_DIALOG(about), "Copyleft 2014-2017. See License for details.");
 
-	gchar *authors[2];
+	const gchar *authors[2];
 	authors[0] = "Assen Totin <assen.totin@gmail.com>";
 	authors[1] = NULL;
-	gtk_about_dialog_set_authors (GTK_ABOUT_DIALOG(about),  &authors[0]);
+	gtk_about_dialog_set_authors (GTK_ABOUT_DIALOG(about),  authors);
 
 	gtk_about_dialog_set_translator_credits(GTK_ABOUT_DIALOG(about), _("translator-credits"));
 


### PR DESCRIPTION
Compiling against a newer version of gtk results in an error about incompatible pointer type. This change fixes that.